### PR TITLE
Move switch actions to switches_action.h

### DIFF
--- a/Arduino_Pedelec_Controller/CMakeLists.txt
+++ b/Arduino_Pedelec_Controller/CMakeLists.txt
@@ -38,6 +38,7 @@ set(${FIRMWARE_NAME}_SRCS                          # Source code
     menu.h
     switches.cpp
     switches.h
+    switches_action.h
     )
 generate_arduino_firmware(${FIRMWARE_NAME})
 

--- a/Arduino_Pedelec_Controller/config.h
+++ b/Arduino_Pedelec_Controller/config.h
@@ -7,6 +7,7 @@
 #else
 #include <Arduino.h>
 #endif
+#include "switches_action.h"
 
 #define HARDWARE_REV 4      //place your hardware revision (1-4) here: x means hardware-revision 1.x
 
@@ -31,21 +32,19 @@
 // Customizable buttons for use with the on-the-go-menu.
 // The menu is activated by the ACTION_ENTER_MENU action (see below).
 //
-enum switch_name { SWITCH_THROTTLE=0, SWITCH_DISPLAY1=1, SWITCH_DISPLAY2=2, _SWITCHES_COUNT=3 };
-
-const switch_name MENU_BUTTON_UP = SWITCH_DISPLAY1;
-const switch_name MENU_BUTTON_DOWN = SWITCH_DISPLAY2;
+// Choose from: SWITCH_THROTTLE, SWITCH_DISPLAY1 and SWITCH_DISPLAY2
+//
+const switch_name MENU_BUTTON_UP = SWITCH_THROTTLE;
+const switch_name MENU_BUTTON_DOWN = SWITCH_DISPLAY1;
 
 // Switch actions: Customizable actions for short and long press
 //
-enum sw_action { ACTION_NONE=0,                // do nothing
-                 ACTION_SET_SOFT_POTI,         // set soft poti
-                 ACTION_SHUTDOWN_SYSTEM,       // power down system
-                 ACTION_ENABLE_BACKLIGHT_LONG, // enable backlight for 60s
-                 ACTION_TOGGLE_BLUETOOTH,      // switch bluetooth on/off
-                 ACTION_ENTER_MENU,            // enter on-the-go settings menu
-};
-
+// Choose from: ACTION_NONE, ACTION_SET_SOFT_POTI, ACTION_SHUTDOWN_SYSTEM
+//              ACTION_ENABLE_BACKLIGHT_LONG, ACTION_TOGGLE_BLUETOOTH,
+//              ACTION_ENTER_MENU
+//
+// The file "switches_action.h" contains a list with descriptions.
+//
 const sw_action SW_THROTTLE_SHORT_PRESS = ACTION_SET_SOFT_POTI;
 const sw_action SW_THROTTLE_LONG_PRESS  = ACTION_SHUTDOWN_SYSTEM;
 

--- a/Arduino_Pedelec_Controller/switches_action.h
+++ b/Arduino_Pedelec_Controller/switches_action.h
@@ -1,0 +1,34 @@
+/*
+Switch actions for use in config.h
+(c) Thomas Jarosch / pedelecforum.de
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+#ifndef SWITCHES_ACTION_H
+#define SWITCHES_ACTION_H
+
+// Switch names
+enum switch_name { SWITCH_THROTTLE=0, SWITCH_DISPLAY1=1, SWITCH_DISPLAY2=2, _SWITCHES_COUNT=3 };
+
+// Switch actions: Customizable actions for short and long press. See config.h
+enum sw_action { ACTION_NONE=0,                // do nothing
+                 ACTION_SET_SOFT_POTI,         // set soft poti
+                 ACTION_SHUTDOWN_SYSTEM,       // power down system
+                 ACTION_ENABLE_BACKLIGHT_LONG, // enable backlight for 60s
+                 ACTION_TOGGLE_BLUETOOTH,      // switch bluetooth on/off
+                 ACTION_ENTER_MENU,            // enter on-the-go settings menu
+               };
+
+#endif


### PR DESCRIPTION
Hi,

I've moved the switch action definitions to an own header file.
Please merge and adapt the APC at the same time.

I didn't want to break the APC on purpose :)
